### PR TITLE
made more linux compatible

### DIFF
--- a/boir.sln
+++ b/boir.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
+# Visual Studio 2012
 VisualStudioVersion = 14.0.22129.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "boir", "boir\boir.csproj", "{CB780313-059F-4E24-A6E0-531F0F3F67BB}"
@@ -15,6 +15,15 @@ Global
 		{CB780313-059F-4E24-A6E0-531F0F3F67BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB780313-059F-4E24-A6E0-531F0F3F67BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB780313-059F-4E24-A6E0-531F0F3F67BB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = boir\boir.csproj
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.FileWidth = 120
+		$1.inheritsSet = VisualStudio
+		$1.inheritsScope = text/plain
+		$1.scope = text/plain
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/boir/ANSI.cs
+++ b/boir/ANSI.cs
@@ -44,7 +44,10 @@ namespace SharpLZW
         {
             for (int i = 0; i < 256; i++)
             {
-                table.Add(System.Text.Encoding.Default.GetString(new byte[1] { Convert.ToByte(i) }), i);
+                string k = System.Text.Encoding.GetEncoding(1252).GetString(new byte[1] { Convert.ToByte (i) });
+                if (table.ContainsKey(k))
+                    Console.WriteLine("{0} {1} {2}", k, i, table[k]);
+                table.Add(k, i);
             }
         }
 

--- a/boir/Program.cs
+++ b/boir/Program.cs
@@ -12,7 +12,15 @@ namespace boir
     {
         static void Main(string[] args)
         {
-            var dir = new DirectoryInfo(@"C:\Program Files (x86)\Steam\SteamApps\common\The Binding of Isaac Rebirth\resources\packed");
+            //windows accepts both forward and back slashes, so i will use the ones that work everywhere
+            string steamDir;
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+                steamDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".local/share/Steam");
+            else
+                steamDir = "C:/Program Files (x86)/Steam";
+
+            var dir = new DirectoryInfo(Path.Combine(steamDir, "SteamApps/common/The Binding of Isaac Rebirth/resources/packed"));
+
             foreach (var file in dir.GetFiles("*.a"))
             {
                 using (var fs = File.OpenRead(file.FullName))

--- a/boir/boir.csproj
+++ b/boir/boir.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
- .csproj file v4 works in monodevelop
- ANSI.cs now reliably uses ANSI codec, not e.g. UTF8
- Program.cs uses the right directory on linux

Bug #1 doesn’t apply to me, but I tried compiling it from MonoDevelop.
