### PR TITLE
Add RecordType (for ogg support, future known types), read Steam dir from registry

### DIFF
--- a/boir/Program.cs
+++ b/boir/Program.cs
@@ -25,6 +25,7 @@ using System.Text;
 using System.Xml;
 using System.Threading.Tasks;
 using System.Reflection;
+using Microsoft.Win32;
 using Newtonsoft.Json;
 
 namespace boir
@@ -38,7 +39,7 @@ namespace boir
             if (Environment.OSVersion.Platform == PlatformID.Unix)
                 steamDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".local/share/Steam");
             else
-                steamDir = "C:/Program Files (x86)/Steam";
+                steamDir = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", "C:/Program Files (x86)/Steam");
 
             var dir = new DirectoryInfo(Path.Combine(steamDir, "SteamApps/common/The Binding of Isaac Rebirth/resources/packed"));
 


### PR DESCRIPTION
Though it looks like I changed the whole Program.cs, I just added a RecordType enum for known record types (currently just xml, png and ogg) and set it when reading inside the Record base class.  Then when we write the record out to a file, I use this record type as the file extension.  This ensures ogg files (video and audio) are written out with the correct extensions, and leaves a hook for future work.  I also made it read the location of the steam dir on windows from the registry.
